### PR TITLE
Fix gem after HttpParty removed traling slashes in base_uri

### DIFF
--- a/lib/qualys/auth.rb
+++ b/lib/qualys/auth.rb
@@ -7,7 +7,7 @@ module Qualys
     # Do Login
     def self.login
       # Request a login
-      response = api_post('session/', body: {
+      response = api_post('/session/', body: {
                             action: 'login',
                             username: Qualys::Config.username,
                             password: Qualys::Config.password
@@ -21,7 +21,7 @@ module Qualys
     # Set Logout
     def self.logout
       # Request a login
-      api_post('session/', body: {
+      api_post('/session/', body: {
                  action: 'logout'
                })
 

--- a/lib/qualys/compliance.rb
+++ b/lib/qualys/compliance.rb
@@ -1,7 +1,7 @@
 module Qualys
   class Compliance < Api
     def self.all
-      response = api_get('compliance/control/', query: { action: 'list' })
+      response = api_get('/compliance/control/', query: { action: 'list' })
 
       unless response.parsed_response['<COMPLIANCE_SCAN_RESULT_OUTPUT']['RESPONSE'].key? 'COMPLIANCE_SCAN'
         return []

--- a/lib/qualys/reports.rb
+++ b/lib/qualys/reports.rb
@@ -1,7 +1,7 @@
 module Qualys
   class Reports < Api
     def self.all
-      response = api_get('report/', query: { action: 'list' })
+      response = api_get('/report/', query: { action: 'list' })
       puts response.parsed_response.inspect
       unless response.parsed_response['SCAN_LIST_OUTPUT']['RESPONSE'].key? 'SCAN_LIST'
         return []

--- a/lib/qualys/scans.rb
+++ b/lib/qualys/scans.rb
@@ -1,7 +1,7 @@
 module Qualys
   class Scans < Api
     def self.all
-      response = api_get('scan/', query: { action: 'list' })
+      response = api_get('/scan/', query: { action: 'list' })
       unless response.parsed_response['SCAN_LIST_OUTPUT']['RESPONSE'].key? 'SCAN_LIST'
         return []
       end
@@ -15,7 +15,7 @@ module Qualys
     end
 
     def self.get(ref)
-      response = api_get('scan/', query: {
+      response = api_get('/scan/', query: {
                            action: 'fetch',
                            scan_ref: ref,
                            mode: 'extended',


### PR DESCRIPTION
HttpParty removes traling slashes at the end of base_uri.
This broke the gem as the request were made to "https://qualysapi.qualys.com/api/2.0/foscan" instead of
"https://qualysapi.qualys.com/api/2.0/fo/scan" for example.

Signed-off-by: alex <alex@cyberwatch.fr>