### PR TITLE
Refactor api

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     qualys (0.1.3)
       erubis
-      httparty
+      httparty (~> 0.15)
       json
 
 GEM

--- a/lib/qualys/api.rb
+++ b/lib/qualys/api.rb
@@ -13,56 +13,50 @@ module Qualys
                                                 'X-Requested-With' => "Qualys Ruby Client v#{Qualys::VERSION}"
                                               })
 
-    #
-    #
-    def self.api_get(url, options = {})
-      unless Qualys::Config.session_key.nil?
-        HTTParty::Basement.default_cookies.add_cookies(Qualys::Config.session_key)
+    class << self
+      def api_get(url, options = {})
+        HTTParty::Basement.default_cookies.add_cookies(Qualys::Config.session_key) unless Qualys::Config.session_key.nil?
+
+        # Send Request
+        response = HTTParty.get(url, options)
+
+        # Check if you need to be authorized
+        check_response(response)
+        # return the response
+        response
       end
 
-      # Send Request
-      response = HTTParty.get(url, options)
+      #
+      #
+      def api_post(url, options = {})
+        HTTParty::Basement.default_cookies.add_cookies(Qualys::Config.session_key) unless Qualys::Config.session_key.nil?
 
-      # Check if you need to be authorized
-      if response.code.eql?(401)
-        raise Qualys::Api::AuthorizationRequired, 'Please Login Before Communicating With The API'
-      elsif response.code.eql?(403)
-        raise Qualys::Api::Exception, response.parsed_response['SIMPLE_RETURN']['RESPONSE']['TEXT']
-      elsif !response.code.eql?(200)
-        raise Qualys::Api::InvalidResponse, 'Invalid Response Received'
+        # Send Request
+        response = HTTParty.post(url, options)
+
+        # Check if you need to be authorized
+        check_response(response)
+        # return the response
+        response
       end
 
-      # return the response
-      response
-    end
-
-    #
-    #
-    def self.api_post(url, options = {})
-      unless Qualys::Config.session_key.nil?
-        HTTParty::Basement.default_cookies.add_cookies(Qualys::Config.session_key)
+      #
+      # Sets the base URI.
+      def base_uri=(base_uri)
+        HTTParty::Basement.default_options.update(base_uri: base_uri)
       end
 
-      # Send Request
-      response = HTTParty.post(url, options)
+      private
 
-      # Check if you need to be authorized
-      if response.code.eql?(401)
-        raise Qualys::Api::AuthorizationRequired, 'Please Configure A Username and Password Before Communicating With The API'
-      elsif response.code.eql?(403)
-        raise Qualys::Api::Exception, response.parsed_response['SIMPLE_RETURN']['RESPONSE']['TEXT']
-      elsif response.code.eql?(500)
-        raise Qualys::Api::InvalidResponse, 'Invalid Response Received'
+      def check_response(response)
+        code = response.code
+        raise(Qualys::Api::AuthorizationRequired, 'Please Login Before Communicating With The API') if code.eql?(401)
+        raise(Qualys::Api::Exception, response.parsed_response['SIMPLE_RETURN']['RESPONSE']['TEXT']) if code.eql?(403)
+        unless code.eql?(200)
+          raise(Qualys::Api::InvalidResponse, 'Invalid Response Received' + response.code.to_s + ' ' +
+              response.request.last_uri.to_s)
+        end
       end
-
-      # return the response
-      response
-    end
-
-    #
-    # Sets the base URI.
-    def self.base_uri=(base_uri)
-      HTTParty::Basement.default_options.update(base_uri: base_uri)
     end
   end
 end

--- a/qualys.gemspec
+++ b/qualys.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
 
   s.add_dependency 'erubis'
-  s.add_dependency 'httparty'
+  s.add_dependency 'httparty', '~> 0.15'
   s.add_dependency 'json'
 
   s.add_development_dependency 'bundler'

--- a/spec/fixtures/vcr_cassettes/api_get.yml
+++ b/spec/fixtures/vcr_cassettes/api_get.yml
@@ -1,0 +1,52 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://qualysapi.qualys.eu/api/2.0/fo/scan/?action=list
+    body:
+      encoding: US-ASCII
+      string: ''
+  response:
+    status:
+      code: 200
+      message: OK
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n<!DOCTYPE SCAN_LIST_OUTPUT
+        SYSTEM \"https://qualysapi.qualys.eu/api/2.0/fo/scan/scan_list_output.dtd\">\n<!--
+        This report was generated with an evaluation version of Qualys //--> \n<SCAN_LIST_OUTPUT>\n
+        \ <RESPONSE>\n    <DATETIME>2017-12-11T12:49:00Z</DATETIME>\n    <SCAN_LIST>\n
+        \     <SCAN>\n        <REF>scan/XXXX633905.79357</REF>\n        <TYPE>On-Demand</TYPE>\n
+        \       <TITLE><![CDATA[shellshock 20171207]]></TITLE>\n        <USER_LOGIN>Thomas</USER_LOGIN>\n
+        \       <LAUNCH_DATETIME>2017-12-07T08:05:05Z</LAUNCH_DATETIME>\n        <DURATION>00:01:43</DURATION>\n
+        \       <PROCESSING_PRIORITY>0 - No Priority</PROCESSING_PRIORITY>\n        <PROCESSED>1</PROCESSED>\n
+        \       <STATUS>\n          <STATE>Error</STATE>\n        </STATUS>\n        <TARGET><![CDATA[47.69.112.62]]></TARGET>\n
+        \     </SCAN>\n      <SCAN>\n        <REF>scan/1512633883.79354</REF>\n        <TYPE>On-Demand</TYPE>\n
+        \       <TITLE><![CDATA[shellshock 20171207]]></TITLE>\n        <USER_LOGIN>Thomas</USER_LOGIN>\n
+        \       <LAUNCH_DATETIME>2017-12-07T08:04:43Z</LAUNCH_DATETIME>\n        <DURATION>00:07:02</DURATION>\n
+        \       <PROCESSING_PRIORITY>0 - No Priority</PROCESSING_PRIORITY>\n        <PROCESSED>1</PROCESSED>\n
+        \       <STATUS>\n          <STATE>Finished</STATE>\n        </STATUS>\n        <TARGET><![CDATA[47.69.112.62]]></TARGET>\n
+        \     </SCAN>\n      <SCAN>\n        <REF>scan/1512633720.79248</REF>\n        <TYPE>On-Demand</TYPE>\n
+        \       <TITLE><![CDATA[shellshock]]></TITLE>\n        <USER_LOGIN>Thomas</USER_LOGIN>\n
+        \       <LAUNCH_DATETIME>2017-12-07T08:01:59Z</LAUNCH_DATETIME>\n        <DURATION>00:00:06</DURATION>\n
+        \       <PROCESSING_PRIORITY>0 - No Priority</PROCESSING_PRIORITY>\n        <PROCESSED>1</PROCESSED>\n
+        \       <STATUS>\n          <STATE>Error</STATE>\n        </STATUS>\n        <TARGET><![CDATA[47.69.112.62]]></TARGET>\n
+        \     </SCAN>\n      <SCAN>\n        <REF>scan/1512469561.67379</REF>\n        <TYPE>On-Demand</TYPE>\n
+        \       <TITLE><![CDATA[test_vuln]]></TITLE>\n        <USER_LOGIN>Thomas</USER_LOGIN>\n
+        \       <LAUNCH_DATETIME>2017-12-05T10:26:01Z</LAUNCH_DATETIME>\n        <DURATION>00:04:48</DURATION>\n
+        \       <PROCESSING_PRIORITY>1 - Emergency</PROCESSING_PRIORITY>\n        <PROCESSED>1</PROCESSED>\n
+        \       <STATUS>\n          <STATE>Finished</STATE>\n        </STATUS>\n        <TARGET><![CDATA[192.168.1.100]]></TARGET>\n
+        \     </SCAN>\n      <SCAN>\n        <REF>scan/1512466786.67046</REF>\n        <TYPE>On-Demand</TYPE>\n
+        \       <TITLE><![CDATA[test]]></TITLE>\n        <USER_LOGIN>Thomas</USER_LOGIN>\n
+        \       <LAUNCH_DATETIME>2017-12-05T09:39:46Z</LAUNCH_DATETIME>\n        <DURATION>00:07:56</DURATION>\n
+        \       <PROCESSING_PRIORITY>0 - No Priority</PROCESSING_PRIORITY>\n        <PROCESSED>1</PROCESSED>\n
+        \       <STATUS>\n          <STATE>Finished</STATE>\n        </STATUS>\n        <TARGET><![CDATA[88.78.187.177]]></TARGET>\n
+        \     </SCAN>\n    </SCAN_LIST>\n  </RESPONSE>\n</SCAN_LIST_OUTPUT>\n<!--
+        This report was generated with an evaluation version of Qualys //--> \n<!--
+        CONFIDENTIAL AND PROPRIETARY INFORMATION. Qualys provides the QualysGuard
+        Service \"As Is,\" without any warranty of any kind. Qualys makes no warranty
+        that the information contained in this report is complete or error-free. Copyright
+        2017, Qualys, Inc. //--> \n"
+    http_version: 
+  recorded_at: Mon, 11 Dec 2017 12:49:00 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/unlogged.yml
+++ b/spec/fixtures/vcr_cassettes/unlogged.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://qualysapi.qualys.eu/api/2.0/fo/scan/?action=list
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Requested-With:
+      - Qualys Ruby Client v0.1.3
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Date:
+      - Mon, 11 Dec 2017 12:54:07 GMT
+      Server:
+      - Qualys
+      X-Xss-Protection:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/xml;charset=UTF-8
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <!DOCTYPE SIMPLE_RETURN SYSTEM "https://qualysapi.qualys.eu/api/2.0/simple_return.dtd">
+        <SIMPLE_RETURN>
+          <RESPONSE>
+            <DATETIME>2017-12-11T12:54:07Z</DATETIME>
+            <CODE>2000</CODE>
+            <TEXT>Bad Login/Password</TEXT>
+          </RESPONSE>
+        </SIMPLE_RETURN>
+    http_version: 
+  recorded_at: Mon, 11 Dec 2017 12:54:07 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/wrong.yml
+++ b/spec/fixtures/vcr_cassettes/wrong.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://qualysapi.qualys.eu/api/2.0/fo/scan
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Requested-With:
+      - Qualys Ruby Client v0.1.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Mon, 11 Dec 2017 12:58:49 GMT
+      Server:
+      - Qualys
+      Location:
+      - https://qualysapi.qualys.eu/api/2.0/fo/scan/
+      Content-Length:
+      - '255'
+      Content-Type:
+      - text/html; charset=iso-8859-1
+    body:
+      encoding: UTF-8
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+        <html><head>
+        <title>301 Moved Permanently</title>
+        </head><body>
+        <h1>Moved Permanently</h1>
+        <p>The document has moved <a href="http://qualysapi.qualys.eu:443/api/2.0/fo/scan/">here</a>.</p>
+        </body></html>
+    http_version: 
+  recorded_at: Mon, 11 Dec 2017 12:58:49 GMT
+- request:
+    method: get
+    uri: https://qualysapi.qualys.eu/api/2.0/fo/scan/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Requested-With:
+      - Qualys Ruby Client v0.1.3
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Mon, 11 Dec 2017 12:58:49 GMT
+      Server:
+      - Qualys
+      X-Xss-Protection:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Pragma:
+      - no-cache
+      X-Ratelimit-Limit:
+      - '300'
+      X-Ratelimit-Window-Sec:
+      - '3600'
+      X-Concurrency-Limit-Limit:
+      - '2'
+      X-Concurrency-Limit-Running:
+      - '0'
+      X-Ratelimit-Towait-Sec:
+      - '0'
+      X-Ratelimit-Remaining:
+      - '294'
+      Connection:
+      - close
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/xml;charset=UTF-8
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <!DOCTYPE SIMPLE_RETURN SYSTEM "https://qualysapi.qualys.eu/api/2.0/simple_return.dtd">
+        <SIMPLE_RETURN>
+          <RESPONSE>
+            <DATETIME>2017-12-11T12:58:49Z</DATETIME>
+            <CODE>1903</CODE>
+            <TEXT>Missing required parameter(s): action</TEXT>
+          </RESPONSE>
+        </SIMPLE_RETURN>
+    http_version: 
+  recorded_at: Mon, 11 Dec 2017 12:58:49 GMT
+recorded_with: VCR 4.0.0

--- a/spec/qualys/api_spec.rb
+++ b/spec/qualys/api_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rubygems'
+
+describe Qualys::Api do
+  describe 'api_get' do
+    let(:query) { Qualys::Api.api_get('/scan/', query: { action: 'list' }) }
+    let(:wrong_query) { Qualys::Api.api_get('/scan') }
+    let(:not_existing_query) { Qualys::Api.api_get('/nonExisting', query: { action: 'list' }) }
+
+    it 'query the API' do
+      VCR.use_cassette('api_get') do
+        expect(query.response.code).to eq '200'
+      end
+    end
+    it 'raises appropriatly' do
+      VCR.use_cassette('unlogged') do
+        expect { query }.to raise_error(Qualys::Api::AuthorizationRequired, 'Please Login Before Communicating With The API')
+      end
+
+      VCR.use_cassette('wrong') do
+        expect { wrong_query }.to raise_error(Qualys::Api::InvalidResponse)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Some code quality improvement for the Api class.
Testing the class
dropping support of HttpParty before 0.15 because it does not delete the trailing backslash at the end of base_url
